### PR TITLE
 Fix Ruffle find rule

### DIFF
--- a/resources/systems/linux/es_find_rules.xml
+++ b/resources/systems/linux/es_find_rules.xml
@@ -807,10 +807,10 @@
     <emulator name="RUFFLE">
         <!-- Adobe Flash player Ruffle -->
         <rule type="systempath">
-            <entry>/app/bin/ruffle-wrapper.sh</entry>   <!-- RetroDECK -->
             <entry>ruffle</entry>
         </rule>
         <rule type="staticpath">
+            <entry>/app/bin/ruffle-wrapper.sh</entry>   <!-- RetroDECK -->
             <entry>~/Applications/ruffle/ruffle</entry>
             <entry>~/.local/share/applications/ruffle/ruffle</entry>
             <entry>~/.local/bin/ruffle/ruffle</entry>


### PR DESCRIPTION
 On branch retrodeck-ruffle
 Changes to be committed:
	modified:   resources/systems/linux/es_find_rules.xml